### PR TITLE
fix: change resolution scope

### DIFF
--- a/maven-plugin/src/main/java/io/github/project/classport/plugin/EmbeddingMojo.java
+++ b/maven-plugin/src/main/java/io/github/project/classport/plugin/EmbeddingMojo.java
@@ -47,8 +47,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Mojo(name = "embed", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, requiresDependencyResolution = ResolutionScope.TEST)
-// @Execute(phase = LifecyclePhase.COMPILE)
+@Mojo(name = "embed", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class EmbeddingMojo
         extends AbstractMojo {
     /**

--- a/maven-plugin/src/main/java/io/github/project/classport/plugin/EmbeddingMojo.java
+++ b/maven-plugin/src/main/java/io/github/project/classport/plugin/EmbeddingMojo.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Mojo(name = "embed", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "embed", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class EmbeddingMojo
         extends AbstractMojo {
     /**


### PR DESCRIPTION
Change the scope to be more fine-grained. We do not embed test dependencies hence we don't need them.

@serenacofano also note that `GENERATE_RESOURCES` is not guaranteeing that dependencies are resolved before embedding. It is the resolution scope. The `defaultPhase` only guarantees that our plugin runs when our plugin is declared in the POM file rather than passed as a CLI argument


> The build lifecycle phase to bind the goals in this execution to. If omitted, the goals will be bound to the default phase specified by the plugin. [[1]](https://maven.apache.org/xsd/maven-4.0.0.xsd)
