### PR TITLE
refactor: try out Daniel's approach

### DIFF
--- a/maven-plugin/src/main/java/io/github/project/classport/plugin/EmbeddingMojo.java
+++ b/maven-plugin/src/main/java/io/github/project/classport/plugin/EmbeddingMojo.java
@@ -30,7 +30,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 
-import io.github.project.classport.commons.AnnotationConstantPool;
 import io.github.project.classport.commons.ClassportHelper;
 import io.github.project.classport.commons.ClassportInfo;
 import io.github.project.classport.commons.Utility;
@@ -97,8 +96,6 @@ public class EmbeddingMojo
 
     private void embedDirectory(Artifact a, File dirToWalk) throws IOException, MojoExecutionException {
         ClassportInfo metadata = getMetadata(a);
-        AnnotationConstantPool acp = new AnnotationConstantPool(metadata);
-        AnnotationConstantPool.ConstantPoolData cpData = acp.getNewEntries();
         if (!dirToWalk.exists()) {
             getLog().info("No classes compiled for " + project.getArtifactId() + ". Skipping.");
             return;
@@ -113,9 +110,9 @@ public class EmbeddingMojo
                     byte[] bytes = in.readAllBytes();
 
                     if (Arrays.equals(Arrays.copyOfRange(bytes, 0, 4), Utility.MAGIC_BYTES)) {
-                        byte[] modifiedCpBytes = acp.injectAnnotation(bytes, cpData);
+                        MetadataAdder adder = new MetadataAdder(bytes);
                         try (FileOutputStream out = new FileOutputStream(file.toFile())) {
-                            out.write(modifiedCpBytes);
+                            out.write(adder.add(metadata));
                         }
                     }
                 }

--- a/maven-plugin/src/main/java/io/github/project/classport/plugin/JarHelper.java
+++ b/maven-plugin/src/main/java/io/github/project/classport/plugin/JarHelper.java
@@ -85,9 +85,6 @@ class JarHelper {
         
         target.getParentFile().mkdirs();
         
-        AnnotationConstantPool acp = new AnnotationConstantPool(metadata);
-        AnnotationConstantPool.ConstantPoolData cpData = acp.getNewEntries();
-        
         Path inJar = source.toPath();
         Path outJar = target.toPath();
         
@@ -121,8 +118,8 @@ class JarHelper {
                 byte[] entryBytes = readEntryBytes(jis, buffer);
                 
                 if (shouldReplace(entry, entryBytes)) {
-                    byte[] replacementBytes = replacementBytes(entryBytes, acp, cpData);
-                    jos.write(replacementBytes);
+                    MetadataAdder adder = new MetadataAdder(entryBytes);
+                    jos.write(adder.add(metadata));
                 } else {
                     // Copy entry as-is
                     jos.write(entryBytes);


### PR DESCRIPTION
Everything is working great but the correctness check fails
```
List of dependencies in the embedded jar:
commons-io:commons-io:jar:2.18.0
commons-logging:commons-logging:jar:1.3.4
info.picocli:picocli:jar:4.7.6
org.apache.pdfbox:jbig2-imageio:jar:3.0.4
org.bouncycastle:bcpkix-jdk18on:jar:1.80
org.bouncycastle:bcprov-jdk18on:jar:1.80
org.bouncycastle:bcutil-jdk18on:jar:1.80
```

I wonder why we don't get pdfbox dependencies even though upon manual checks, I see they are embedded in the jar.