### PR TITLE
fix: comparison of id and sourceProjectID

### DIFF
--- a/classport-analyser/src/main/java/io/github/project/classport/analyser/CorrectnessAnalyser.java
+++ b/classport-analyser/src/main/java/io/github/project/classport/analyser/CorrectnessAnalyser.java
@@ -84,7 +84,7 @@ public class CorrectnessAnalyser {
         boolean usesDependencies = false;
         for (ClassportInfo c : sbom.values()) {
             project = c.sourceProjectId();
-            if (c.id() != c.sourceProjectId()) {
+            if (!c.id().equals(c.sourceProjectId())) {
                 usesDependencies = true;
                 System.out.println(c.id());
             }


### PR DESCRIPTION
Related #85 

My approach got more dependencies because we had duplicates in constant pool so the string `==` passed. The correct way to know equality is to read `Main-Class` and set the source project ID.