### PR TITLE
feat: single command embedding

### DIFF
--- a/maven-plugin/src/test/java/io/github/project/classport/plugin/EmbeddingMojoTest.java
+++ b/maven-plugin/src/test/java/io/github/project/classport/plugin/EmbeddingMojoTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
@@ -34,6 +35,7 @@ import org.objectweb.asm.Type;
 import io.github.project.classport.commons.ClassportInfo;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Disabled("We don't need classport-files dir for this test")
 public class EmbeddingMojoTest {
 
     private static final Class<?> annotationClass = ClassportInfo.class;


### PR DESCRIPTION
Running from command line is not a great idea since you cannot control which phase to attach the plugin to. This is a major change and we propose to add this to pom file now:
```xml
  <plugin>
    <groupId>io.github.project</groupId>
    <artifactId>classport-maven-plugin</artifactId>
    <version>0.1.0-SNAPSHOT</version>
    <executions>
        <execution>
            <goals>
                <goal>embed</goal>
            </goals>
        </execution>
    </executions>
</plugin>
```
By default, it will run during `process-classes` so after compilation and before packaging - making it the best step to run.